### PR TITLE
only compile first page for thumbnail

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,10 +4,7 @@ example.pdf: lib.typ template/main.typ
 	typst compile template/main.typ example.pdf --root .
 
 template/thumbnail.png: lib.typ template/main.typ
-	typst compile template/main.typ {n}.png --root . && \
-		mv 1.png template/thumbnail.png && \
-		rm *.png
-	
+	typst compile template/main.typ template/thumbnail.png --pages 1 --root . 
 
 .PHONY: clean
 clean:


### PR DESCRIPTION
Typst 0.12 introduces compilation of specific pages. This PR simplifies the template thumbnail creation to only compile the title page.